### PR TITLE
add differentiated tag for extract; utc-8 encoding

### DIFF
--- a/redmed/redmedTagger.py
+++ b/redmed/redmedTagger.py
@@ -82,7 +82,7 @@ class redmedTagger():
                 if i in hit_indices:
                     out_strs.append("<" + flag + ">")
                     _ = [out_strs.append(x) for x in preserved_tokens[i + phrase_adjust:i + phrase_adjust + 2]]
-                    out_strs.append("<" + flag + ">")
+                    out_strs.append("</" + flag + ">")
                     if len(flags) > 1:
                         j += 1
                         if j < len(flags):
@@ -96,7 +96,7 @@ class redmedTagger():
                 if i in hit_indices:
                     out_strs.append("<" + flag + ">")
                     out_strs.append(preserved_tokens[i + phrase_adjust])
-                    out_strs.append("<" + flag + ">")
+                    out_strs.append("</" + flag + ">")
                     if len(flags) > 1:
                         j += 1
                         if j < len(flags):
@@ -115,7 +115,7 @@ class redmedTagger():
             if i in hit_indices:
                 out_strs.append("<" + flag + ">")
                 out_strs.append(tok)
-                out_strs.append("<" + flag + ">")
+                out_strs.append("</" + flag + ">")
                 if len(flags) > 1:
                     j += 1
                     if j < len(flags):

--- a/redmed/textHandler.py
+++ b/redmed/textHandler.py
@@ -13,7 +13,7 @@ class textHandler():
     def __init__(self, phrasePath=curPath2):
         self.phrases = set()
         with open(
-            phrasePath
+            phrasePath, encoding='utf-8'
         ) as inPhrases:
             for phrase in inPhrases:
                 self.phrases.add(phrase.strip())


### PR DESCRIPTION
I noticed that the tagger.general_drug_flagging and the tagger.get_mention_counts behaved differently outside of tagger.get_mention_counts normalizing the lexicon.  I wanted to pull the drug names from the general_drug_flagging but it wasn't possible to extract with regex if there was more than one drug identified.  So I made a distinction between the open tag and closing tag ==  <drug_related> </drug_related>.

Now the regex 
`(?<=<drug_related>)([\s\S]*?)(?=<\/drug_related>)  `
will identify both uses of "adderall" in the text.

> "i had to take a drug test to get hired. i take <drug_related> adderall </drug_related> , so i tested positive for amphetamines . but i had a prescription , so i passed. the employer  didn 't see my <drug_related> adderall </drug_related> test

When I was updating the code, your redmed_phrases.txt errored out due to lacking encoding so I added utc-8.  

Thanks for your work!